### PR TITLE
Update build:package to move all babel-* dependencies to devDependencies

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -28,8 +28,12 @@ gulp.task('build:package', ['clean'], () => {
     gulp.src('./package.json')
         .pipe(editor( (p) => {
             p.main = 'lib/safe-parse';
-            p.devDependencies['babel-core'] = p.dependencies['babel-core'];
-            delete p.dependencies['babel-core'];
+            Object.keys(p.dependencies).forEach( (dep) => {
+                if (/^babel-/.test(dep)) {
+                    p.devDependencies[dep] = p.dependencies[dep];
+                    delete p.dependencies[dep];
+                }
+            });
             return p;
         }))
         .pipe(gulp.dest('build'));


### PR DESCRIPTION
v1.0.2 is causing an extra ~30-70MB of dependencies to be installed and generating npm warnings for people using npm 2.x because its dependencies look like this:

```js
  "dependencies": {
    "babel-plugin-add-module-exports": "0.1.1",
    "babel-preset-es2015-loose": "6.1.3",
    "babel-preset-stage-0": "6.3.13",
    "postcss": "^5.0.13"
  },
```